### PR TITLE
Link to code of conduct

### DIFF
--- a/call-for-speakers.html
+++ b/call-for-speakers.html
@@ -218,7 +218,7 @@ link_class: hoc-link
     <p>
       We want to create a safe and welcoming space for our community members. This means there
       will be no tolerance towards harassment of any kind. By attending Heart of Clojure you
-      agree to our Code of Conduct. Please read and adhere to it.
+      agree to our <a href="https://berlincodeofconduct.org/">Code of Conduct</a>. Please read and adhere to it.
     </p>
   </section>
 


### PR DESCRIPTION
Adding a link to the code of conduct (we use the Berlin Code of Conduct).

I also renamed `call-for-presentations.html` to `call-for-speakers.html`, since that's the URL it is under.