### PR TITLE
Fix menu on mobile

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,9 +10,9 @@
 
   <div class="nav-menu w-100">
     <div class="flex">
-      <a class="link nav-home pa2 flex-grow-1" href="/">
+      <div class="pa2 flex-grow-1">
         <span class="pa3 db b black">Menu</span>
-      </a>
+      </div>
       <div class="pa2">
           <a class="db bg-pink-t60 pa3 br2 white b link" href="{{site.tickets_url}}">Get your ticket</a>
       </div>


### PR DESCRIPTION
Before, clicking the menu always sent you to the homepage instead of showing you the menu content.