### PR TITLE
Trigger mobile menu styles earlier

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -33,7 +33,7 @@ nav {
     background-color: rgba(231,135,157,0.25);
 }
 
-@media screen and (min-width: 30em) {
+@media screen and (min-width: 52em) {
     .nav-menu { display: none; }
     .nav-bar {
       display: block;


### PR DESCRIPTION
Otherwise there is a state when resizing where the menu text flow breaks out of it's container.

Changing from 
<img width="603" alt="Screenshot 2019-05-26 at 14 10 33" src="https://user-images.githubusercontent.com/738978/58381665-17210880-7fc0-11e9-8f5b-920f4b96ab24.png">

to

<img width="599" alt="Screenshot 2019-05-26 at 14 10 43" src="https://user-images.githubusercontent.com/738978/58381667-1b4d2600-7fc0-11e9-99c3-ee0fa68750ab.png">

